### PR TITLE
small fix for dplyr 1.0.0

### DIFF
--- a/R/format_engr.R
+++ b/R/format_engr.R
@@ -154,7 +154,7 @@ format_engr <- function(x, sigdig = NULL, ambig_0_adj = FALSE) {
 
   # for rejoining later, add observation numbers to each df
   obs_add <- function(x) {
-    x <- dplyr::mutate(x, observ_index = 1:dplyr::n())
+    x <- dplyr::mutate(x, observ_index = dplyr::row_number())
   }
   numeric_as_is <- obs_add(numeric_as_is)
   numeric_engr <- obs_add(numeric_engr)


### PR DESCRIPTION
using `dplyr::row_number()` instead of `1:dplyr::n()` because when `n()` is 0, you'd get c(1, 0) which causes this problem: 

```
── 2. Error: (unknown) (@test_format_engr.R#55)  ───────────────────────────────
Problem with `mutate()` input `observ_index`.
✖ Input `observ_index` can't be recycled to size 0.
ℹ Input `observ_index` is `1:dplyr::n()`.
ℹ Input `observ_index` must be size 0 or 1, not 2.
Backtrace:
  1. base::do.call(docxtools::format_engr, my_args)
  3. docxtools:::obs_add(numeric_as_is)
  5. dplyr:::mutate.data.frame(x, observ_index = 1:dplyr::n())
  6. dplyr:::mutate_cols(.data, ...)
  7. base::tryCatch(...)
  8. base:::tryCatchList(expr, classes, parentenv, handlers)
  9. base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
 10. value[[3L]](cond)
 11. dplyr:::stop_mutate_recycle_incompatible_size(e, index = i, dots = dots)
 12. dplyr:::stop_dplyr(...)
```