### PR TITLE
Update test

### DIFF
--- a/tests/testthat/test_put.R
+++ b/tests/testthat/test_put.R
@@ -18,7 +18,10 @@ test_that("put_axes() attributes match expectations", {
   expect_identical(p$theme$plot.margin, unit(c(0, 0, 0, 0), "mm"))
 
   p <- put_axes(col = "blue", linewidth = 1)
-  expect_identical(p$layers[[1]]$geom$non_missing_aes, c("linetype", "linewidth", "shape"))
+  expect_identical(
+    p$layers[[1]]$geom$non_missing_aes,
+    geom_segment()$geom$non_missing_aes
+  )
 
   p <- put_axes(2)
   expect_true(purrr::is_empty(p$mapping))


### PR DESCRIPTION
Hi there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break docxtools.

This PR updates a test to deal with an internal field we've changed in ggplot2. Generally, we don't recommend testing for the state of ggplot2 internals, but the new test should deal with future changes to the `non_missing_aes` field as well.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help docxtools get out a fix if necessary.